### PR TITLE
Blank groupchat name when ShowPresenceColoredNames is selected

### DIFF
--- a/src/main/java/de/pixart/messenger/ui/adapter/ListItemAdapter.java
+++ b/src/main/java/de/pixart/messenger/ui/adapter/ListItemAdapter.java
@@ -111,7 +111,7 @@ public class ListItemAdapter extends ArrayAdapter<ListItem> {
             viewHolder.tags.setAlpha(INACTIVE_ALPHA);
         } else {
             if (ShowPresenceColoredNames()) {
-                viewHolder.name.setTextColor(color);
+                viewHolder.name.setTextColor(color != 0 ? color : Color.get(activity, R.attr.text_Color_Main));
             } else {
                 viewHolder.name.setTextColor(Color.get(activity, R.attr.text_Color_Main));
             }


### PR DESCRIPTION
When ShowPresenceColoredNames is checked, all groupchat names are being displayed as blank (no name) in group chats contact list.

This is fix is to assign default color when no color value is assigned. (PS: this is my very first git pull request, please guide if I made any mistake. thanks)
