### PR TITLE
README show count of users in muc

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Alternativ kannst du den Messenger direkt aus hier von GitHub unter [Releases](h
 #### Ich habe Probleme, was soll ich tun?
 Am einfachsten ist es, wenn du unserer Support-Gruppe beitrittst, dort werden deine Probleme mit Sicherheit schnell gelöst. 
 
-[support@room.pix-art.de](https://jabber.pix-art.de/j/support@room.pix-art.de?join) 
+[![Users in muc](https://inverse.chat/badge.svg?room=support@room.pix-art.de)](https://jabber.pix-art.de/j/support@room.pix-art.de?join): [support@room.pix-art.de](https://jabber.pix-art.de/j/support@room.pix-art.de?join) 
 
 oder scanne den QR-Code:
 


### PR DESCRIPTION
https://github.com/genofire/Pix-Art-Messenger/blob/muc-users-readme/README.md

Or looks it better beside the `Pix-Art Messenger` at beginning, like in CI ?

![c](https://user-images.githubusercontent.com/6905586/48233649-f7245180-e3ad-11e8-99ba-849cadd0a12c.png)
