### PR TITLE
Change default: Notification from strangers: True

### DIFF
--- a/src/main/res/values/defaults.xml
+++ b/src/main/res/values/defaults.xml
@@ -67,7 +67,7 @@
     <bool name="vibrate_on_notification">true</bool>
     <bool name="led">true</bool>
     <string name="notification_ringtone">content://settings/system/notification_sound</string>
-    <bool name="notifications_from_strangers">false</bool>
+    <bool name="notifications_from_strangers">true</bool>
     <bool name="headsup_notifications">true</bool>
     <bool name="enable_quiet_hours">false</bool>
     <bool name="manually_change_presence">true</bool>


### PR DESCRIPTION
Hi,

I'd like to suggest:     <bool name="notifications_from_strangers">true</bool>

Why?
In my words, Pix-Art focuses in easy and simple XMPP. Therefore, lots of new people, which are also new to XMPP, will join this app. As they, when creating a new account, most likely will not experience any spam attacks that quickly (or ever), I'd suggest to trade this 'danger' for much easier onboarding. This means, when I add someone (I do the step, to make it even easier for them) I expect that they get my first 'Hello' without the need to tell them to open the app to see my first message. I guess the user expects this, too.

So, my idea is, to switch on noftification from the 'nice' strangers :)

Still, if someone really want this off - the option is of course in the settings!

Cheers