### PR TITLE
move messageExport to last step

### DIFF
--- a/src/main/java/de/pixart/messenger/services/ExportBackupService.java
+++ b/src/main/java/de/pixart/messenger/services/ExportBackupService.java
@@ -319,10 +319,10 @@ public class ExportBackupService extends Service {
                 final String uuid = account.getUuid();
                 accountExport(db, uuid, writer);
                 simpleExport(db, Conversation.TABLENAME, Conversation.ACCOUNT, uuid, writer);
-                messageExport(db, uuid, writer, progress);
                 for (String table : Arrays.asList(SQLiteAxolotlStore.PREKEY_TABLENAME, SQLiteAxolotlStore.SIGNED_PREKEY_TABLENAME, SQLiteAxolotlStore.SESSION_TABLENAME, SQLiteAxolotlStore.IDENTITIES_TABLENAME)) {
                     simpleExport(db, table, SQLiteAxolotlStore.ACCOUNT, uuid, writer);
                 }
+                messageExport(db, uuid, writer, progress);
                 writer.flush();
                 writer.close();
                 Log.d(Config.LOGTAG, "written backup to " + file.getAbsoluteFile());


### PR DESCRIPTION
On this way, it is possible to failed on import and get a well working restore (after omemo was imported correct).
Messages are less important and could be fetched from server.