### PR TITLE
F-Droid nightly repo: move to chris

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - run: export GRADLE_USER_HOME=$PWD/.gradle
       - run: echo y | sdkmanager "platforms;android-$(sed -n 's,.*compileSdkVersion\s*\([0-9][0-9]*\).*,\1,p' build.gradle)" > /dev/null
       # workaround for fdroid nightly circleci bug
-      - run: sed -i "s/os.getenv('CIRCLE_REPOSITORY_URL')/\"https:\/\/github.com\/genofire\/Pix-Art-Messenger\"/" /usr/lib/python3/dist-packages/fdroidserver/nightly.py
+      - run: sed -i "s/os.getenv('CIRCLE_REPOSITORY_URL')/\"https:\/\/github.com\/kriztan\/Pix-Art-Messenger\"/" /usr/lib/python3/dist-packages/fdroidserver/nightly.py
       # generate version number
       - run: sed -i "s/^\(\s*versionCode\s*\).*$/\1$(git rev-list --first-parent --count HEAD)/" build.gradle
       - run: sed -i "0,/versionName/s/^\(\s*versionName\).*/\1 \"$(printf '%s-%05d' $(git describe --tag --abbrev=0) $(git rev-list --first-parent --count HEAD))\"/" build.gradle


### PR DESCRIPTION
@kriztan
## Step 1
du musst nun ein sign-key für das Repo generieren:
```sh
keytool -genkey -v -keystore de.pixart.messenger-debug.keystore \             
  -keyalg RSA -keysize 2048 -validity 10000 \
  -alias androiddebugkey -storepass android -keypass android \
  -dname "CN=Android Debug,O=Android,C=US"
```

## Step 2
Keys extracten:
```sh
fdroid nightly --keystore de.pixart.messenger-debug.keystore --show-secret-var
```
Output:
```
Importing keystore de.pixart.messenger-debug.keystore to /tmp/.kj97a9es/.keystore.p12...
writing RSA key
INFO: 
SSH Public Key to be used as Deploy Key:
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDIz9yy0PnJMvX8W4Q+74XnItbggasp54YUOT4yn8AT2iR3mUxBWkFWncumRMbsilaUtgTLaRJrk9TjKjpFsfm9TZwow9bWTRjtvSDVAyOP4rliLd/GJWuC5w92/Q1E+gDrmXc4SJv2Fjzw37uVr+tO3M0ug731K89Xd79qKtmLOC9gJOSawe5rGqCYSfy46IWUcn43NY/29ITgWomoJFWLaCu/7dshsckhfQmJIhDfBGnOSO2/6UrbRP/76MnRCkMVeZwHeGa22jdPnZUAe3fBHd2/1ojuo3WZfs0P7biPdTJQ5I9G/HwAYsnzMqIxQ3pNQhJ860f4/KKCmLpPVnf7 /tmp/.kj97a9es/debug_keystore_V9zU9ylontFwg8FPYA7pkEuiDCaDYfw2qofad13wGjY_id_rsa

de.pixart.messenger-debug.keystore encoded for the DEBUG_KEYSTORE secret variable:
Der ganze restliche misst.
```


## Step 3
SSH-Key bei github als Deploy-Write Key hinterlegen: ungefähr [hier](https://github.com/kriztan/Pix-Art-Messenger-nightly/settings/keys/new)

## Step 4
Den base64-privatekey bei CircleCI hinterlegen.
In einer EnviromentVariable unter den Namen `DEBUG_KEYSTORE` (im Beispiel-Output `Der ganze restliche misst.`)
