### PR TITLE
Fix empty grey box for unknown file types

### DIFF
--- a/src/main/java/de/pixart/messenger/ui/adapter/MessageAdapter.java
+++ b/src/main/java/de/pixart/messenger/ui/adapter/MessageAdapter.java
@@ -634,29 +634,27 @@ public class MessageAdapter extends ArrayAdapter<Message> implements CopyTextVie
         viewHolder.richlinkview.setVisibility(View.GONE);
         viewHolder.download_button.setVisibility(View.VISIBLE);
         final String mimeType = message.getMimeType();
-        if (mimeType != null) {
-            if (message.getMimeType().contains("pdf")) {
-                viewHolder.download_button.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_file_pdf_grey600_48dp, 0, 0, 0);
-                viewHolder.download_button.setText(activity.getString(R.string.open_x_file, UIHelper.getFileDescriptionString(activity, message)));
-            } else if (message.getMimeType().contains("vcard")) {
-                try {
-                    showVCard(message, viewHolder);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            } else if (message.getMimeType().contains("calendar")) {
-                viewHolder.download_button.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_calendar_grey600_48dp, 0, 0, 0);
-                viewHolder.download_button.setText(activity.getString(R.string.open_x_file, UIHelper.getFileDescriptionString(activity, message)));
-            } else if (message.getMimeType().equals("application/vnd.android.package-archive")) {
-                try {
-                    showAPK(message, viewHolder);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            } else {
-                viewHolder.download_button.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_file_grey600_48dp, 0, 0, 0);
-                viewHolder.download_button.setText(activity.getString(R.string.open_x_file, UIHelper.getFileDescriptionString(activity, message)));
+        if (mimeType != null && message.getMimeType().contains("pdf")) {
+            viewHolder.download_button.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_file_pdf_grey600_48dp, 0, 0, 0);
+            viewHolder.download_button.setText(activity.getString(R.string.open_x_file, UIHelper.getFileDescriptionString(activity, message)));
+        } else if (mimeType != null && message.getMimeType().contains("vcard")) {
+            try {
+                showVCard(message, viewHolder);
+            } catch (Exception e) {
+                e.printStackTrace();
             }
+        } else if (mimeType != null && message.getMimeType().contains("calendar")) {
+            viewHolder.download_button.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_calendar_grey600_48dp, 0, 0, 0);
+            viewHolder.download_button.setText(activity.getString(R.string.open_x_file, UIHelper.getFileDescriptionString(activity, message)));
+        } else if (mimeType != null && message.getMimeType().equals("application/vnd.android.package-archive")) {
+            try {
+                showAPK(message, viewHolder);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        } else {
+            viewHolder.download_button.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_file_grey600_48dp, 0, 0, 0);
+            viewHolder.download_button.setText(activity.getString(R.string.open_x_file, UIHelper.getFileDescriptionString(activity, message)));
         }
         viewHolder.download_button.setOnClickListener(v -> openDownloadable(message));
     }

--- a/src/main/java/de/pixart/messenger/utils/MimeUtils.java
+++ b/src/main/java/de/pixart/messenger/utils/MimeUtils.java
@@ -323,6 +323,7 @@ public final class MimeUtils {
         add("text/plain", "text");
         add("text/plain", "diff");
         add("text/plain", "po");     // reserve "pot" for vnd.ms-powerpoint
+        add("text/plain", "ass");
         add("text/richtext", "rtx");
         add("text/rtf", "rtf");
         add("text/text", "phps");


### PR DESCRIPTION
Previously if files, whose mime-type was not recognized by MimeUtils, were being sent to a Pix-Art-Client only a grey box without text would be shown.
With this commit the general "open file" text is now shown for these files. Previously this text was only shown for files with recognized mime-types, not being specially handled (like images).

Also the Advanced SSA (*.ass) subtitle format was added to MimeUtils as 'text/plain'.