### PR TITLE
Disable NewLines in Base64 values

### DIFF
--- a/src/main/java/de/pixart/messenger/entities/ServiceDiscoveryResult.java
+++ b/src/main/java/de/pixart/messenger/entities/ServiceDiscoveryResult.java
@@ -156,7 +156,7 @@ public class ServiceDiscoveryResult {
     }
 
     public String getVer() {
-        return new String(Base64.encode(this.ver, Base64.DEFAULT)).trim();
+        return Base64.encodeToString(this.ver, Base64.NO_WRAP);
     }
 
     public List<Identity> getIdentities() {

--- a/src/main/java/de/pixart/messenger/generator/AbstractGenerator.java
+++ b/src/main/java/de/pixart/messenger/generator/AbstractGenerator.java
@@ -103,7 +103,7 @@ public abstract class AbstractGenerator {
             s.append(feature).append('<');
         }
         byte[] sha1 = md.digest(s.toString().getBytes());
-        return new String(Base64.encode(sha1, Base64.DEFAULT)).trim();
+        return Base64.encodeToString(sha1, Base64.NO_WRAP);
     }
 
     public static String getTimestamp(long time) {

--- a/src/main/java/de/pixart/messenger/generator/IqGenerator.java
+++ b/src/main/java/de/pixart/messenger/generator/IqGenerator.java
@@ -263,17 +263,17 @@ public class IqGenerator extends AbstractGenerator {
         final Element signedPreKeyPublic = bundle.addChild("signedPreKeyPublic");
         signedPreKeyPublic.setAttribute("signedPreKeyId", signedPreKeyRecord.getId());
         ECPublicKey publicKey = signedPreKeyRecord.getKeyPair().getPublicKey();
-        signedPreKeyPublic.setContent(Base64.encodeToString(publicKey.serialize(), Base64.DEFAULT));
+        signedPreKeyPublic.setContent(Base64.encodeToString(publicKey.serialize(), Base64.NO_WRAP));
         final Element signedPreKeySignature = bundle.addChild("signedPreKeySignature");
-        signedPreKeySignature.setContent(Base64.encodeToString(signedPreKeyRecord.getSignature(), Base64.DEFAULT));
+        signedPreKeySignature.setContent(Base64.encodeToString(signedPreKeyRecord.getSignature(), Base64.NO_WRAP));
         final Element identityKeyElement = bundle.addChild("identityKey");
-        identityKeyElement.setContent(Base64.encodeToString(identityKey.serialize(), Base64.DEFAULT));
+        identityKeyElement.setContent(Base64.encodeToString(identityKey.serialize(), Base64.NO_WRAP));
 
         final Element prekeys = bundle.addChild("prekeys", AxolotlService.PEP_PREFIX);
         for (PreKeyRecord preKeyRecord : preKeyRecords) {
             final Element prekey = prekeys.addChild("preKeyPublic");
             prekey.setAttribute("preKeyId", preKeyRecord.getId());
-            prekey.setContent(Base64.encodeToString(preKeyRecord.getKeyPair().getPublicKey().serialize(), Base64.DEFAULT));
+            prekey.setContent(Base64.encodeToString(preKeyRecord.getKeyPair().getPublicKey().serialize(), Base64.NO_WRAP));
         }
 
         return publish(AxolotlService.PEP_BUNDLES + ":" + deviceId, item, publishOptions);
@@ -287,13 +287,13 @@ public class IqGenerator extends AbstractGenerator {
         for (int i = 0; i < certificates.length; ++i) {
             try {
                 Element certificate = chain.addChild("certificate");
-                certificate.setContent(Base64.encodeToString(certificates[i].getEncoded(), Base64.DEFAULT));
+                certificate.setContent(Base64.encodeToString(certificates[i].getEncoded(), Base64.NO_WRAP));
                 certificate.setAttribute("index", i);
             } catch (CertificateEncodingException e) {
                 Log.d(Config.LOGTAG, "could not encode certificate");
             }
         }
-        verification.addChild("signature").setContent(Base64.encodeToString(signature, Base64.DEFAULT));
+        verification.addChild("signature").setContent(Base64.encodeToString(signature, Base64.NO_WRAP));
         return publish(AxolotlService.PEP_VERIFICATION + ":" + deviceId, item);
     }
 


### PR DESCRIPTION
Smack gets confused and throws NullPointerException
when Base64 contains newlines. Therefor disable newlines
in Base64. I assume newlines in Base64 are also not
expected by other implementations.