### PR TITLE
Clearer account menu

### DIFF
--- a/src/main/java/de/pixart/messenger/ui/ManageAccountActivity.java
+++ b/src/main/java/de/pixart/messenger/ui/ManageAccountActivity.java
@@ -154,10 +154,12 @@ public class ManageAccountActivity extends XmppActivity implements OnAccountUpda
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.manageaccounts, menu);
         MenuItem addAccount = menu.findItem(R.id.action_add_account);
+        MenuItem addAccountMenu = menu.findItem(R.id.action_add_account_menu);
         MenuItem addAccountWithCertificate = menu.findItem(R.id.action_add_account_with_cert);
 
         if (Config.X509_VERIFICATION) {
             addAccount.setVisible(false);
+            addAccountMenu.setVisible(false);
             addAccountWithCertificate.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
         }
 
@@ -192,6 +194,10 @@ public class ManageAccountActivity extends XmppActivity implements OnAccountUpda
         }
         switch (item.getItemId()) {
             case R.id.action_add_account:
+                startActivity(new Intent(this, EditAccountActivity.class));
+                overridePendingTransition(R.animator.fade_in, R.animator.fade_out);
+                break;
+            case R.id.action_add_account_menu:
                 startActivity(new Intent(this, EditAccountActivity.class));
                 overridePendingTransition(R.animator.fade_in, R.animator.fade_out);
                 break;

--- a/src/main/res/menu/manageaccounts.xml
+++ b/src/main/res/menu/manageaccounts.xml
@@ -8,14 +8,18 @@
         android:title="@string/action_add_new_account"
         app:showAsAction="always" />
     <item
-        android:id="@+id/action_import_backup"
-        android:title="@string/restore_backup"
-        app:showAsAction="never" />
-    <item
         android:id="@+id/action_add_account_with_cert"
         android:icon="?attr/icon_add_person"
         android:title="@string/action_add_account_with_certificate"
         android:visible="true"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/action_add_account_menu"
+        android:title="@string/action_add_new_account"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/action_import_backup"
+        android:title="@string/restore_backup"
         app:showAsAction="never" />
     <item
         android:id="@+id/action_settings"


### PR DESCRIPTION
i know this pr is not as obvious as the 2 others, this is why i made it separately...
here is why we should add that on the menu as well, when we are on the menu we do expect to have all the available option plus the normal add account function become non visible behind the menu when we open it, if we don't pay attention to the icon function for adding an account we may think that it's not available as it's not on the menu