### PR TITLE
[BUGFIX] happy eye: null pointer if no connection was etablished

### DIFF
--- a/src/main/java/de/pixart/messenger/utils/Resolver.java
+++ b/src/main/java/de/pixart/messenger/utils/Resolver.java
@@ -275,6 +275,10 @@ public class Resolver {
         try {
             result = executor.invokeAny(r);
             executor.shutdown();
+            if (result == null) {
+                Log.i(Config.LOGTAG, Resolver.class.getSimpleName() + ": happy eyeball unable to connect to one address");
+                return null;
+            }
             Thread disconnector = new Thread(() -> {
                 while (true) {
                     try {


### PR DESCRIPTION
Ich hab offensichtlich zu schlecht den fall, das gar keine Verbindung aufgebaut werden kann getestet ;(

Sorry, für die ganzen Bugs (und der entstandene Aufwand) ...