### PR TITLE
README: Linux log instructions

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -68,10 +68,12 @@ If we can't fix your problem there, you can open an issue here on github, detail
 #### GNU/Linux, OSX and other Unix-like systems:
 
 1. First install The **A**ndroid **D**ebugging **B**ridge, if not already present.
-    ###### Ubuntu / Linux Mint
+    ###### Debian and derivates like Ubuntu / Linux Mint
     ```
     sudo apt-get update
-    sudo apt-get install android-tools-adb
+    sudo apt-get update adb
+    # Debian Jessie or older:
+    # sudo apt-get install android-tools-adb
     ```
     ###### openSUSE 42.2 and 42.3
     ```
@@ -137,4 +139,4 @@ If we can't fix your problem there, you can open an issue here on github, detail
     ``` 
 12. Now reproduce the issue encountered.
 
-13. Stop logging. Now take a close look at your log file and remove any personal and private information you may find before sending it together with a detailed description of your issue, instructions on how to reproduce to me. You can use GitHub's issue tracker: [Issues](https://github.com/kriztan/Pix-Art-Messenger/issues)
+13. Stop logging (`Ctrl+C`). Now take a close look at your log file and remove any personal and private information you may find before sending it together with a detailed description of your issue, instructions on how to reproduce to me. You can use GitHub's issue tracker: [Issues](https://github.com/kriztan/Pix-Art-Messenger/issues)

--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ Solltest du dort nicht weiter kommen kannst du hier ein Issue erstellen, in welc
 ##### Linux:
 
 1. Installation von ADB
-    ###### Ubuntu / Linux Mint
+    ###### Debian und Derivate wie Ubuntu / Linux Mint
     ```
     sudo apt-get update
-    sudo apt-get install android-tools-adb
+    sudo apt-get install adb
+    # For Debian Jessie and older
+    # sudo apt-get install android-tools-adb
     ```
     ###### openSUSE 42.2 und 42.3
     ```
@@ -72,7 +74,13 @@ Solltest du dort nicht weiter kommen kannst du hier ein Issue erstellen, in welc
     alternativ kann auch der `1 Click Installer` benutzt werden:    
     https://software.opensuse.org/package/android-tools
     
-2. Navigiere mit `cd` in das Verzeichnis deines Vertrauens und fahre mit Schritt [6] unter [Windows] fort. s.u.
+2. Navigiere im Terminal mit `cd` in das Verzeichnis deines Vertrauens
+3. Folge den Schritten [6] bis [10] unter [Windows]. s.u.
+4. Nun kannst du mit der Ausgabe der Debug-Logs beginnen. Nenne die Log-Datei bspw `logcat.txt`:
+   ```
+   $ adb -d logcat -v time | grep -i Pix-Art > logcat.txt
+   ```
+5. Fahre nun mit den verbliebenen Schritten unter [Windows] ab Schritt [12] fort.
 
 ##### Windows:
 
@@ -112,4 +120,6 @@ Solltest du dort nicht weiter kommen kannst du hier ein Issue erstellen, in welc
     ``` 
 12. Führe nun die Schritte aus, die zum Fehler führen.
 
-13. Zum Schluss schaue dir die `logcat.txt` an, lösche ggf. persönliche Angaben und sende diese Datei zur Problemlösung mit einer Beschreibung des Fehlers und was man tun muss, um diesen Fehler zu erhalten, an mich. Nutz dafür den Menüpunkt [Issues](https://github.com/kriztan/Pix-Art-Messenger/issues)
+13. Nachdem der Fehler reproduziert wurde, kann das Loggen im Terminal mit `Strg+C` beendet werden.
+
+14. Zum Schluss schaue dir die `logcat.txt` an, lösche ggf. persönliche Angaben und sende diese Datei zur Problemlösung mit einer Beschreibung des Fehlers und was man tun muss, um diesen Fehler zu erhalten, an mich. Nutz dafür den Menüpunkt [Issues](https://github.com/kriztan/Pix-Art-Messenger/issues)


### PR DESCRIPTION
Iirc it did happen sometimes that someone in the support MUC tried to log with `FINDSTR` under Linux.

Also `android-tools-adb` is just a transitional package pointing to `adb` in newer Debian versions and will eventually be removed from new releases. (Same for derivates)