### PR TITLE
Include chapril.org in suggested servers.

### DIFF
--- a/src/main/res/values/defaults.xml
+++ b/src/main/res/values/defaults.xml
@@ -198,6 +198,7 @@
         <item>nsa.li</item>
         <item>blabber.im</item>
         <item>buzon.uy</item>
+        <item>chapril.org</item>
     </string-array>
 
     <string-array name="support_domains">


### PR DESCRIPTION
*chapril.org* is a fresh new public XMPP server allowing in-band registration. We would be happy to have it listed in Pix-Art.
This service is run by a french community also running other public services. The Web page describing the XMPP service is https://www.chapril.org/XMPP.html